### PR TITLE
Provide a default implementation of BlockDevice::write

### DIFF
--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -16,7 +16,7 @@ impl MemDev {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl BlockDevice for MemDev {
     async fn read(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), std::io::Error> {
         let offset = offset as usize;

--- a/src/device.rs
+++ b/src/device.rs
@@ -16,7 +16,9 @@ pub trait BlockDevice {
     /// Read a block from offset.
     async fn read(&mut self, offset: u64, buf: &mut [u8]) -> io::Result<()>;
     /// Write a block of data at offset.
-    async fn write(&mut self, offset: u64, buf: &[u8]) -> io::Result<()>;
+    async fn write(&mut self, _offset: u64, _buf: &[u8]) -> io::Result<()> {
+        Err(io::ErrorKind::InvalidInput.into())
+    }
     /// Size of a block on device.
     fn block_size(&self) -> u32;
     /// Number of blocks on device.

--- a/src/device.rs
+++ b/src/device.rs
@@ -11,7 +11,7 @@ use tokio::{fs::OpenOptions, io::AsyncRead, io::AsyncReadExt, io::AsyncWriteExt,
 use crate::{nbd, sys};
 
 /// A block device.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait BlockDevice {
     /// Read a block from offset.
     async fn read(&mut self, offset: u64, buf: &mut [u8]) -> io::Result<()>;


### PR DESCRIPTION
To simplify implementation of read-only NBD devices, provide a default
implementation of BlockDevice::write that returns an error.