### PR TITLE
Add read-only option to serve_local_nbd

### DIFF
--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -34,7 +34,7 @@ impl BlockDevice for MemDev {
 async fn main() {
     let nbd_path = std::env::args().nth(1).expect("NDB device path");
     let dev = MemDev::new(512, 128);
-    nbd_async::serve_local_nbd(nbd_path, dev.block_size, dev.num_blocks as u64, dev)
+    nbd_async::serve_local_nbd(nbd_path, dev.block_size, dev.num_blocks as u64, false, dev)
         .await
         .unwrap();
 }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -5,21 +5,21 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use nix::{errno::Errno, libc::ioctl, request_code_none};
 
 // Flags are there
-const HAS_FLAGS: u64 = 1;
+pub const HAS_FLAGS: u64 = 1;
 // Device is read-only
-const READ_ONLY: u64 = 1 << 1;
+pub const READ_ONLY: u64 = 1 << 1;
 // Send FLUSH
-const SEND_FLUSH: u64 = 1 << 2;
+pub const SEND_FLUSH: u64 = 1 << 2;
 // Send FUA (Force Unit Access)
-const SEND_FUA: u64 = 1 << 3;
+pub const SEND_FUA: u64 = 1 << 3;
 // Use elevator algorithm - rotational media
-const ROTATIONAL: u64 = 1 << 4;
+pub const ROTATIONAL: u64 = 1 << 4;
 // Send TRIM (discard)
-const SEND_TRIM: u64 = 1 << 5;
+pub const SEND_TRIM: u64 = 1 << 5;
 // Send NBD_CMD_WRITE_ZEROES
-const SEND_WRITE_ZEROES: u64 = 1 << 6;
+pub const SEND_WRITE_ZEROES: u64 = 1 << 6;
 // Multiple connections are okay
-const CAN_MULTI_CONN: u64 = 1 << 8;
+pub const CAN_MULTI_CONN: u64 = 1 << 8;
 
 pub fn set_sock<F>(f: &F, sock: RawFd) -> io::Result<i32>
 where


### PR DESCRIPTION
Add an option to set NBD_READ_ONLY on the device node serve_local_nbd connects to. This marks the block device as read-only, helping certain userspace tools.

This is a breaking API change. Alternatively, a second method serve_local_nbd_ro might make sense and only require to bump the minor version.

Happy to hear feedback, thanks for the previous work!