### PR TITLE
Update nbd-async to tokio 1.0 and nix 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbd-async"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Olle Sandberg <olle@b3rg.se>"]
 license = "MIT"
 readme = "README.md"
@@ -14,11 +14,11 @@ categories = ["filesystem", "asynchronous", "os", "network-programming"]
 async-trait = "0.1"
 byteorder = "1.3"
 futures = "0.3"
-nix = "0.18"
-tokio = { version = "0.2", features = ["fs", "uds"] }
+nix = "0.19"
+tokio = { version = "1.0", features = ["io-util", "fs", "net"] }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["fs", "uds", "macros"] }
+tokio = { version = "1.0", features = ["io-util", "fs", "net", "rt-multi-thread", "rt", "macros"] }
 
 [profile.release.build-override]
 opt-level = 0


### PR DESCRIPTION
This change is a breaking change as tokio 1.0 code can't run with a tokio 0.2 executor and vice versa.