### PR TITLE
Graceful shutdown of block device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 byteorder = "1.4"
 futures-util = { version = "0.3", default-features = false }
 nix = "0.24"
-tokio = { version = "1.0", features = ["io-util", "fs", "net", "time"] }
+tokio = { version = "1.0", features = ["io-util", "fs", "net"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "fs", "net", "rt-multi-thread", "rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 byteorder = "1.4"
 futures-util = { version = "0.3", default-features = false }
 nix = "0.24"
-tokio = { version = "1.0", features = ["io-util", "fs", "net"] }
+tokio = { version = "1.0", features = ["io-util", "fs", "net", "time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "fs", "net", "rt-multi-thread", "rt", "macros"] }

--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use nbd_async::BlockDevice;
+use nbd_async::{BlockDevice, NoControl};
 
 struct MemDev {
     data: Vec<u8>,
@@ -34,7 +34,14 @@ impl BlockDevice for MemDev {
 async fn main() {
     let nbd_path = std::env::args().nth(1).expect("NDB device path");
     let dev = MemDev::new(512, 128);
-    nbd_async::serve_local_nbd(nbd_path, dev.block_size, dev.num_blocks as u64, false, dev)
-        .await
-        .unwrap();
+    nbd_async::serve_local_nbd(
+        nbd_path,
+        dev.block_size,
+        dev.num_blocks as u64,
+        false,
+        dev,
+        NoControl,
+    )
+    .await
+    .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ mod device;
 mod nbd;
 mod sys;
 
-pub use device::{attach_device, serve_local_nbd, serve_nbd, BlockDevice};
+pub use device::{attach_device, serve_local_nbd, serve_nbd, BlockDevice, Control, NoControl};


### PR DESCRIPTION
Dear @oll3 

I really like your nbd-async crate. The only feature i really missed is the option to do a graceful shutdown of the device so i can do any clean up tasks that i need to do before the app is terminated.

I also needed to schedule some periodic clean up jobs, the only way possible for me to use locks with mutex to be able to do clean up jobs internally, which I didn't like using locks because it means that normal read/write operations will always have to acquire the lock to operate.

So what I did was to introduce a `control` stream that i can send control messages over (this can be a tokio receiver), and it's up to the device to handle, those messages as needed.

I tried to be backward compatible as possible, you can see there is a minimal change to the example.

The deviec can then handle the control message (notify for janitor jobs) and shutdown (so it can gracefully shutdown)

Thanks