### PR TITLE
Provide both `Send` and non-`Send` APIs

### DIFF
--- a/examples/mem.rs
+++ b/examples/mem.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use nbd_async::BlockDevice;
+use nbd_async::BlockDeviceSend;
 
 struct MemDev {
     data: Vec<u8>,
@@ -16,8 +16,8 @@ impl MemDev {
     }
 }
 
-#[async_trait(?Send)]
-impl BlockDevice for MemDev {
+#[async_trait]
+impl BlockDeviceSend for MemDev {
     async fn read(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), std::io::Error> {
         let offset = offset as usize;
         buf.copy_from_slice(&self.data[offset..offset + buf.len()]);
@@ -34,7 +34,7 @@ impl BlockDevice for MemDev {
 async fn main() {
     let nbd_path = std::env::args().nth(1).expect("NDB device path");
     let dev = MemDev::new(512, 128);
-    nbd_async::serve_local_nbd(nbd_path, dev.block_size, dev.num_blocks as u64, false, dev)
+    nbd_async::serve_local_nbd_send(nbd_path, dev.block_size, dev.num_blocks as u64, false, dev)
         .await
         .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,7 @@ mod device;
 mod nbd;
 mod sys;
 
-pub use device::{attach_device, serve_local_nbd, serve_nbd, BlockDevice};
+pub use device::{
+    attach_device, serve_local_nbd, serve_local_nbd_send, serve_nbd, serve_nbd_send, BlockDevice,
+    BlockDeviceSend,
+};


### PR DESCRIPTION
This provides versions of `BlockDevice`, `serve_nbd`, and
`serve_local_nbd` that work with `Send`.

The duplication is unfortunate, but hard to avoid given the current
state of async. This may get easier in the future.

closes: #11